### PR TITLE
Configure hatch build targets and centralize version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "awsailab"
-version = "0.1.0"
+dynamic = ["version"]
 description = "AWS AI research and development laboratory"
 authors = [
     {name = "AWS AI Lab", email = "noreply@example.com"}
@@ -22,6 +22,15 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/awsailab/_version.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/awsailab"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src/awsailab"]
 
 [tool.ruff]
 target-version = "py310"

--- a/src/awsailab/__init__.py
+++ b/src/awsailab/__init__.py
@@ -1,0 +1,12 @@
+"""AWS AI Lab Python package.
+
+This package provides helper utilities and integrations used throughout the
+AWS AI Lab research environment. It currently exposes metadata that can be
+used by downstream tooling during editable installs.
+"""
+
+from __future__ import annotations
+
+from ._version import __version__
+
+__all__ = ["__version__"]

--- a/src/awsailab/_version.py
+++ b/src/awsailab/_version.py
@@ -1,0 +1,7 @@
+"""Package version metadata for awsailab."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- configure Hatch build targets to explicitly include the `awsailab` package and source dynamic version metadata
- move the version string into `awsailab._version` and re-export it from the package init for reuse

## Testing
- `uv sync --frozen`


------
https://chatgpt.com/codex/tasks/task_e_68cde15f2804832a900368f1e5ac2047